### PR TITLE
Enforce param-case on module name

### DIFF
--- a/src/codegen/.hygen/templates/powerhouse/generate-document-model-module/index.ts
+++ b/src/codegen/.hygen/templates/powerhouse/generate-document-model-module/index.ts
@@ -1,4 +1,5 @@
 import { DocumentModelState } from 'document-model/document-model';
+import { paramCase } from 'change-case';
 import { Args } from '../generate-document-model';
 
 type ModuleArgs = Args & { module: string };
@@ -14,10 +15,11 @@ export default {
         const filteredModules = latestSpec.modules.filter(
             m => m.name === args.module,
         );
+
         return {
             rootDir: args.rootDir,
             documentType: documentModel.name,
-            module: args.module,
+            module: paramCase(args.module),
             actions:
                 filteredModules.length > 0
                     ? filteredModules[0].operations.map(a => ({

--- a/src/codegen/.hygen/templates/powerhouse/generate-document-model/index.ts
+++ b/src/codegen/.hygen/templates/powerhouse/generate-document-model/index.ts
@@ -1,3 +1,4 @@
+import { paramCase } from 'change-case';
 import { DocumentModelState } from 'document-model/document-model';
 
 function documentModelToString(documentModel: DocumentModelState) {
@@ -40,7 +41,10 @@ export default {
             documentTypeId: documentModel.id,
             documentType: documentModel.name,
             extension: documentModel.extension,
-            modules: latestSpec.modules,
+            modules: latestSpec.modules.map(m => ({
+                ...m,
+                name: paramCase(m.name),
+            })),
             initialStateValue: latestSpec.state.initialValue,
             fileExtension: documentModel.extension,
         };

--- a/src/codegen/hygen.ts
+++ b/src/codegen/hygen.ts
@@ -1,6 +1,5 @@
 import 'ts-node/register/transpile-only';
 import { DocumentModelState, utils } from 'document-model/document-model';
-import { paramCase } from 'change-case';
 import { Logger, runner } from 'hygen';
 import path from 'path';
 import fs from 'fs';
@@ -105,9 +104,7 @@ export async function generateDocumentModel(
     // Generate the module-specific files for the document model logic
     const latestSpec =
         documentModel.specifications[documentModel.specifications.length - 1];
-    const modules = latestSpec.modules.map((m: { name: string }) =>
-        paramCase(m.name),
-    );
+    const modules = latestSpec.modules.map(m => m.name);
     for (let i = 0; i < modules.length; i++) {
         await run(
             [


### PR DESCRIPTION
Fixes https://github.com/powerhouse-inc/powerhouse/issues/1

Module name is transformed to `param-case` to be used as name for folders and files.