### PR TITLE
fix: add prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "clean": "rimraf dist/",
         "copy-files": "copyfiles -u 1 src/codegen/.hygen/templates/**/*.esm.t dist/",
         "build": "yarn clean && tsc && yarn copy-files",
+        "prepublishOnly": "yarn build",
         "build:create-lib": "tsc --project src/create-lib/tsconfig.json",
         "publish:create-lib": "yarn publish --cwd ./src/create-lib/",
         "start": "ts-node src/cli.ts",

--- a/src/codegen/.hygen/templates/powerhouse/generate-document-model/rootIndex.esm.t
+++ b/src/codegen/.hygen/templates/powerhouse/generate-document-model/rootIndex.esm.t
@@ -3,9 +3,9 @@ to: "<%= rootDir %>/<%= h.changeCase.param(documentType) %>/index.ts"
 force: true
 ---
 /**
-* This is a scaffold file meant for customization.
-* Delete the file and run the code generator again to have it reset
-*/
+ * This is a scaffold file meant for customization.
+ * Delete the file and run the code generator again to have it reset
+ */
 
 import { actions as BaseActions, DocumentModel } from 'document-model/document';
 import { actions as <%= h.changeCase.pascal(documentType) %>Actions, <%= h.changeCase.pascal(documentType) %> } from './gen';
@@ -28,17 +28,10 @@ export const module: DocumentModel<
     reducer,
     actions,
     utils,
-    documentModel
+    documentModel,
 };
 
-export {
-    <%= h.changeCase.pascal(documentType) %>,
-    Document,
-    reducer,
-    actions,
-    utils,
-    documentModel
-}
+export { <%= h.changeCase.pascal(documentType) %>, Document, reducer, actions, utils, documentModel }
 
 export * from './gen/types';
 export * from './src/utils';


### PR DESCRIPTION
It is easy to forget to run `yarn build` when publishing the lib.

According to the [npm scripts docs](https://docs.npmjs.com/cli/v9/using-npm/scripts), the current best practice for this is to use the `prepublishOnly` script for this. The `prepare` script also runs on `yarn install` which is not what we want.

I have also modified the spacing in the rootIndex template. We want to run `yarn generate` before linting in the `document-model-libs`, and those index files are not part of /gen and are therefore seen by eslint and prettier. I have updated the spacing to match what prettier wants, because otherwise the generated files would keep on triggering the linting.